### PR TITLE
Allow composer require with Symfony 3 application

### DIFF
--- a/Runner/LiquibaseRunner.php
+++ b/Runner/LiquibaseRunner.php
@@ -1,7 +1,7 @@
 <?php
 namespace RtxLabs\LiquibaseBundle\Runner;
-use Symfony\Component\HttpKernel\Util\Filesystem;
-use Symfony\Component\Process\Process;
+
+use Symfony\Component\Filesystem\Filesystem;
 
 class LiquibaseRunner
 {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "symfony/framework-bundle": "2.*"
+    "symfony/framework-bundle": "2.* || 3.*"
   },
   "autoload": {
     "psr-0": { "RtxLabs\\LiquibaseBundle": "" }


### PR DESCRIPTION
Thanks for this bundle.

I'm new to PHP but fluent with Liquibase, and need this bundle to install on latest symfony version, so here's a small pull request that fix the symfony-framework version requirements.

I plan to open another pull request to allow more customization of liquibase command, because I need to use an globally installed version of liquibase instead of the embedded one, and a custom JDBC driver (postgreSQL)